### PR TITLE
Support non x86 architectures when building (ARM for example)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,91 @@
+name: Build and Push
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_version:
+        description: 'Version tag for the Docker image'
+        required: true
+        type: string
+        default: 'latest'
+
+env:
+  IMAGE: git.moreira.com/jcollas/kiwix-serve
+
+jobs:
+  build-amd64:
+    runs-on: linux/amd64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config-inline: |
+            [registry."git.moreira.com"]
+              insecure = true
+
+      - uses: docker/login-action@v3
+        with:
+          registry: git.moreira.com
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          tags: ${{ env.IMAGE }}:${{ inputs.image_version }}-amd64
+          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache-amd64
+          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache-amd64,mode=max
+
+  build-arm64:
+    runs-on: linux/arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config-inline: |
+            [registry."git.moreira.com"]
+              insecure = true
+
+      - uses: docker/login-action@v3
+        with:
+          registry: git.moreira.com
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          provenance: false
+          tags: ${{ env.IMAGE }}:${{ inputs.image_version }}-arm64
+          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache-arm64
+          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache-arm64,mode=max
+
+  merge:
+    needs: [build-amd64, build-arm64]
+    runs-on: linux/amd64
+    steps:
+      - uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config-inline: |
+            [registry."git.moreira.com"]
+              insecure = true
+
+      - uses: docker/login-action@v3
+        with:
+          registry: git.moreira.com
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.IMAGE }}:${{ inputs.image_version }} \
+            ${{ env.IMAGE }}:${{ inputs.image_version }}-amd64 \
+            ${{ env.IMAGE }}:${{ inputs.image_version }}-arm64

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -2,7 +2,9 @@
 
 # Get most recent version of 'kiwix-tools' from its channel's feed.xml
 wget https://download.kiwix.org/release/kiwix-tools/feed.xml
-TAR_FILE="$(grep -oP '(?<=<title>)kiwix-tools_linux-x86_64.*(?=</title>)' feed.xml | head -1 )"
+ARCH=`arch`
+FILE_NAME="(?<=<title>)kiwix-tools_linux-$ARCH.*(?=</title>)"
+TAR_FILE="$(grep -oP $FILE_NAME feed.xml | head -1 )"
 
 # Install latest version of kiwix-tools
 wget -O "${TAR_FILE}" https://download.kiwix.org/release/kiwix-tools/"${TAR_FILE}"


### PR DESCRIPTION
Tiny patch which allows building image that works on ARM (Apple M1, Raspberry Pi).  Makes it easy to build multi-architecture docker images.